### PR TITLE
Create .gitattributes to limit files included when installing via AssetLib

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
Installing from scratch unfortunately includes a bunch of items into the base repo of the project, instead of only those elements of the /addons/ folder contents.

It's a pretty easy fix. Nathan Hoad's Dialogue Manager add-on has the desired behaviour. I poked through the code for his addon and found that it seems to accomplish the behaviour simply via a **".gitattributes"** file. I've commited a copy of his, verbatim. I left the text-auto line in, [here's why](https://stackoverflow.com/questions/21472971/what-is-the-purpose-of-text-auto-in-gitattributes-file).

https://github.com/nathanhoad/godot_dialogue_manager/blob/main/.gitattributes

Thanks for the great project, super simple to implement and very handy. Much cleaner and more flexible than my earlier hacky implementation.