### PR TITLE
Modification to oversize system - fix for single-sheet users

### DIFF
--- a/addons/LPCAnimatedSprite/LPCSpriteSheet.gd
+++ b/addons/LPCAnimatedSprite/LPCSpriteSheet.gd
@@ -20,22 +20,10 @@ var NormalAnimationData:Array[LPCAnimationData] = [
 	LPCAnimationData.new(7,"CAST_LEFT",1, 0,false),
 	LPCAnimationData.new(7,"CAST_DOWN",2, 0,false),
 	LPCAnimationData.new(7,"CAST_RIGHT",3, 0,false),
-	LPCAnimationData.new(8,"THRUST_UP",4, 0,false),
-	LPCAnimationData.new(8,"THRUST_LEFT",5, 0,false),
-	LPCAnimationData.new(8,"THRUST_DOWN",6, 0,false),
-	LPCAnimationData.new(8,"THRUST_RIGHT",7, 0,false),
 	LPCAnimationData.new(8,"WALK_UP",8, 0,true),
 	LPCAnimationData.new(8,"WALK_LEFT",9, 0,true),
 	LPCAnimationData.new(8,"WALK_DOWN",10, 0,true),
 	LPCAnimationData.new(8,"WALK_RIGHT",11, 0,true),
-	LPCAnimationData.new(6,"SLASH_UP",12, 0,false),
-	LPCAnimationData.new(6,"SLASH_LEFT",13, 0,false),
-	LPCAnimationData.new(6,"SLASH_DOWN",14, 0,false),
-	LPCAnimationData.new(6,"SLASH_RIGHT",15, 0,false),
-	LPCAnimationData.new(6,"WHIP_UP",12, 0,false),
-	LPCAnimationData.new(6,"WHIP_LEFT",13, 0,false),
-	LPCAnimationData.new(6,"WHIP_DOWN",14, 0,false),
-	LPCAnimationData.new(6,"WHIP_RIGHT",15, 0,false),
 	LPCAnimationData.new(13,"SHOOT_UP",16, 0,false),
 	LPCAnimationData.new(13,"SHOOT_LEFT",17, 0,false),
 	LPCAnimationData.new(13,"SHOOT_DOWN",18, 0,false),
@@ -47,25 +35,43 @@ var NormalAnimationData:Array[LPCAnimationData] = [
 	LPCAnimationData.new(1,"IDLE_RIGHT",11, 0,false),
 	LPCAnimationData.new(1,"HURT_DOWN_LAST",20, 5,false),
 ]
-var SlashAnimationData:Array[LPCAnimationData] = [
-	LPCAnimationData.new(6,"SLASH_UP",0, 0,false),
-	LPCAnimationData.new(6,"SLASH_LEFT",1, 0,false),
-	LPCAnimationData.new(6,"SLASH_DOWN",2, 0,false),
-	LPCAnimationData.new(6,"SLASH_RIGHT",3, 0,false),
-]
-var ThrustAnimationData:Array[LPCAnimationData] = [
-	LPCAnimationData.new(6,"THRUST_UP",0, 0,false),
-	LPCAnimationData.new(6,"THRUST_LEFT",1, 0,false),
-	LPCAnimationData.new(6,"THRUST_DOWN",2, 0,false),
-	LPCAnimationData.new(6,"THRUST_RIGHT",3, 0,false),
-]
-var RodAnimationData:Array[LPCAnimationData] = [
+var OversizeRodAnimationData:Array[LPCAnimationData] = [
 	LPCAnimationData.new(6,"ROD_UP",0, 0,false),
 	LPCAnimationData.new(6,"ROD_LEFT",1, 0,false),
 	LPCAnimationData.new(6,"ROD_DOWN",2, 0,false),
 	LPCAnimationData.new(6,"ROD_RIGHT",3, 0,false),
 ]
+var ThrustAnimationData:Array[LPCAnimationData] = [
+	LPCAnimationData.new(8,"THRUST_UP",4, 0,false),
+	LPCAnimationData.new(8,"THRUST_LEFT",5, 0,false),
+	LPCAnimationData.new(8,"THRUST_DOWN",6, 0,false),
+	LPCAnimationData.new(8,"THRUST_RIGHT",7, 0,false),
+]
+var OversizeThrustAnimationData:Array[LPCAnimationData] = [
+	LPCAnimationData.new(6,"THRUST_UP",0, 0,false),
+	LPCAnimationData.new(6,"THRUST_LEFT",1, 0,false),
+	LPCAnimationData.new(6,"THRUST_DOWN",2, 0,false),
+	LPCAnimationData.new(6,"THRUST_RIGHT",3, 0,false),
+]
+var SlashAnimationData:Array[LPCAnimationData] = [
+	LPCAnimationData.new(6,"SLASH_UP",12, 0,false),
+	LPCAnimationData.new(6,"SLASH_LEFT",13, 0,false),
+	LPCAnimationData.new(6,"SLASH_DOWN",14, 0,false),
+	LPCAnimationData.new(6,"SLASH_RIGHT",15, 0,false),
+]
+var OversizeSlashAnimationData:Array[LPCAnimationData] = [
+	LPCAnimationData.new(6,"SLASH_UP",0, 0,false),
+	LPCAnimationData.new(6,"SLASH_LEFT",1, 0,false),
+	LPCAnimationData.new(6,"SLASH_DOWN",2, 0,false),
+	LPCAnimationData.new(6,"SLASH_RIGHT",3, 0,false),
+]
 var WhipAnimationData:Array[LPCAnimationData] = [
+	LPCAnimationData.new(6,"WHIP_UP",12, 0,false),
+	LPCAnimationData.new(6,"WHIP_LEFT",13, 0,false),
+	LPCAnimationData.new(6,"WHIP_DOWN",14, 0,false),
+	LPCAnimationData.new(6,"WHIP_RIGHT",15, 0,false),
+]
+var OversizeWhipAnimationData:Array[LPCAnimationData] = [
 	LPCAnimationData.new(8,"WHIP_UP",0, 0,false),
 	LPCAnimationData.new(8,"WHIP_LEFT",1, 0,false),
 	LPCAnimationData.new(8,"WHIP_DOWN",2, 0,false),
@@ -78,17 +84,19 @@ func Size() -> int:
 			return 64
 		_:
 			return 192
+
+func AddIfOversized(oversize_type, over: Array[LPCAnimationData], normal: Array[LPCAnimationData]) -> Array[LPCAnimationData]:
+	if SpriteType == oversize_type:
+		return over
+	else:
+		return normal
+
 func AnimationData() -> Array[LPCAnimationData]:
-	match SpriteType:
-		SpriteTypeEnum.Normal:
-			return NormalAnimationData
-		SpriteTypeEnum.OversizeRod:
-			return RodAnimationData
-		SpriteTypeEnum.OversizeThrust:
-			return ThrustAnimationData
-		SpriteTypeEnum.OversizeSlash:
-			return SlashAnimationData
-		SpriteTypeEnum.OversizeWhip:
-			return WhipAnimationData
-		_:
-			return NormalAnimationData
+	var _animationData: Array = NormalAnimationData
+		
+	_animationData.append_array(AddIfOversized(SpriteTypeEnum.OversizeRod, OversizeRodAnimationData, []))
+	_animationData.append_array(AddIfOversized(SpriteTypeEnum.OversizeThrust, OversizeThrustAnimationData, ThrustAnimationData))
+	_animationData.append_array(AddIfOversized(SpriteTypeEnum.OversizeSlash, OversizeSlashAnimationData, SlashAnimationData))
+	_animationData.append_array(AddIfOversized(SpriteTypeEnum.OversizeWhip, OversizeWhipAnimationData, WhipAnimationData))
+	
+	return _animationData


### PR DESCRIPTION
Hi Alex,

This rewrite allows permits using a single-sheet setup with the new oversize data. Otherwise only oversize animation tiles are created. 

Let me know what you think.