### PR TITLE
Emit a signal after animation completes

### DIFF
--- a/addons/LPCAnimatedSprite/LPCAnimatedSprite2D.gd
+++ b/addons/LPCAnimatedSprite/LPCAnimatedSprite2D.gd
@@ -3,6 +3,8 @@ extends Node2D
 
 class_name LPCAnimatedSprite2D
 
+signal animation_over()
+
 @export var SpriteSheets:Array[LPCSpriteSheet]
 @export var DefaultAnimation:LPCAnimation = LPCAnimation.IDLE_DOWN
 
@@ -40,14 +42,24 @@ func _ready():
 		LoadAnimations()
 		
 func play(animation: LPCAnimation, fps: float = 5.0):
+	var signal_flag: bool = false
+	var total_duration: float = 0
 	var sprites = get_children() as Array[AnimatedSprite2D]
 	for sprite in sprites:
 		if sprite.sprite_frames.has_animation(AnimationNames[animation]):
 			sprite.visible = true
 			sprite.sprite_frames.set_animation_speed(AnimationNames[animation], fps)
 			sprite.play(AnimationNames[animation])
+			if not signal_flag:
+				var speed: float = sprite.sprite_frames.get_animation_speed(AnimationNames[animation])
+				var count: float = float(sprite.sprite_frames.get_frame_count(AnimationNames[animation]))
+				total_duration = count / speed
+				signal_flag = true
 		else:
 			sprite.visible = false
+	if signal_flag:
+		await get_tree().create_timer(total_duration).timeout
+		animation_over.emit()
 
 func _notification(what):
 	if what == NOTIFICATION_EDITOR_POST_SAVE:


### PR DESCRIPTION
Hey Alex,

I wanted to be able to run some animations during cutscene dialogue and couldn't find a way to limit an action to a single repetition. This was my best solution, though it's not perfect. With this code I'm able to play an animation, then await the new signal to know it's done.

![image](https://github.com/alextrevisan/LPCAnimatedSprite2D/assets/5817861/68952edb-e529-45cf-aab0-48f4f816f3e2)

I don't like using flags that much but I needed to do it this way to ensure I'm grabbing a sprite with the used animation (in the case of multiple sprites) to not brake functionality for people using the add-on that way. Make sure it's flagged to avoid sending the signal multiple times.

Also to note that I use the add-on purely in code (no scene tree entry) so the signal cannot be linked with a node in the scene-tree to achieve this.

Open to your thoughts.