### PR TITLE
Fix for Walking and Hurt Down Last Animations

### DIFF
--- a/addons/LPCAnimatedSprite/LPCAnimatedSprite2D.gd
+++ b/addons/LPCAnimatedSprite/LPCAnimatedSprite2D.gd
@@ -99,7 +99,7 @@ func AddAnimation(spriteSheet:LPCSpriteSheet, spriteFrames:SpriteFrames, animati
 		spriteFrames.remove_animation(animationData.Name)
 		
 	spriteFrames.add_animation(animationData.Name)
-	var frameStart = animationData.FrameCount -1 if animationData.Reverse else animationData.Col
+	var frameStart = animationData.FrameCount -1 if animationData.Reverse else 0
 	var frameEnd = animationData.Col -1 if animationData.Reverse else animationData.FrameCount
 	var reversed = -1 if animationData.Reverse else 1
 	for frame in range(frameStart, frameEnd , reversed):

--- a/addons/LPCAnimatedSprite/LPCAnimatedSprite2D.gd
+++ b/addons/LPCAnimatedSprite/LPCAnimatedSprite2D.gd
@@ -100,7 +100,7 @@ func AddAnimation(spriteSheet:LPCSpriteSheet, spriteFrames:SpriteFrames, animati
 		
 	spriteFrames.add_animation(animationData.Name)
 	var frameStart = animationData.FrameCount -1 if animationData.Reverse else 0
-	var frameEnd = animationData.Col -1 if animationData.Reverse else animationData.FrameCount
+	var frameEnd = -1 if animationData.Reverse else animationData.FrameCount
 	var reversed = -1 if animationData.Reverse else 1
 	for frame in range(frameStart, frameEnd , reversed):
 		var atlasTexture = AtlasTexture.new()


### PR DESCRIPTION
All animations that have a Col offset were double skipping past that many frames (All Walking started at frame 2 of the animation, and Hurt Down Last skipped to frame 10 (non-existent thus defaulting to Idle Up))