### PR TITLE
Add config to auto publish to asset library

### DIFF
--- a/.github/asset-template.json.hb
+++ b/.github/asset-template.json.hb
@@ -1,0 +1,13 @@
+{
+  "title": "LPCAnimatedSprite2D",
+  "description": "With this addon you simply add a LPC spritesheet to a character and it automaticly generates the animations for the Godot4 sprites",
+  "category_id": "5",
+  "godot_version": "4.2",
+  "version_string": "{{ context.release.tag_name }}",
+  "cost": "MIT",
+  "download_provider": "GitHub",
+  "download_commit": "{{ env.GITHUB_SHA }}",
+  "browse_url": "{{ context.repository.html_url }}",
+  "issues_url": "https://github.com/alextrevisan/LPCAnimatedSprite2D/issues",
+  "icon_url": "https://raw.githubusercontent.com/alextrevisan/LPCAnimatedSprite2D/main/icon.png"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,12 @@ jobs:
         run: git tag -l | grep v$(make version) || make publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Godot Asset Lib
+        uses: deep-entertainment/godot-asset-lib-action@v0.5.0
+        with:
+          username: alextrevisan
+          password: ${{ secrets.GODOT_ASSET_STORE_PASSWORD }}
+          assetId: 2212
+          approveDirectly: "true"
+          assetTemplate: .github/asset-template.json.hb


### PR DESCRIPTION
I found an example to automaticly publish to the godot asset library

Doc: https://github.com/marketplace/actions/godot-asset-lib